### PR TITLE
4.2 updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
         "php": ">=7.0.0",
         "classpreloader/classpreloader": "~1.0.2",
         "d11wtq/boris": "~1.0",
-        "ircmaxell/password-compat": "~1.0",
         "filp/whoops": "^2.1",
         "jeremeamia/superclosure": "~1.0.1",
         "monolog/monolog": "~1.6",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=7.0.0",
         "classpreloader/classpreloader": "~1.0.2",
         "d11wtq/boris": "~1.0",
         "ircmaxell/password-compat": "~1.0",
@@ -70,15 +70,16 @@
         "aws/aws-sdk-php": "~2.6",
         "iron-io/iron_mq": "~1.5",
         "pda/pheanstalk": "~2.1",
-        "mockery/mockery": "~0.9",
-        "phpunit/phpunit": "~4.0"
+        "mockery/mockery": "~1.1",
+        "phpunit/phpunit": "~6.0"
     },
     "autoload": {
         "classmap": [
             "src/Illuminate/Queue/IlluminateQueueClosure.php"
         ],
         "files": [
-            "src/Illuminate/Support/helpers.php"
+            "src/Illuminate/Support/helpers.php",
+            "tests/TestCase.php"
         ],
         "psr-0": {
             "Illuminate": "src/"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "classpreloader/classpreloader": "~1.0.2",
         "d11wtq/boris": "~1.0",
         "ircmaxell/password-compat": "~1.0",
-        "filp/whoops": "1.1.*",
+        "filp/whoops": "^2.1",
         "jeremeamia/superclosure": "~1.0.1",
         "monolog/monolog": "~1.6",
         "nesbot/carbon": "~1.0",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '2'
+services:
+
+  # The Application
+  app:
+    build:
+      context: ./
+      dockerfile: docker/app.dockerfile
+    working_dir: /var/www
+    volumes:
+      - ./:/var/www
+
+#  # The Test Database
+#  test_db:
+#    build:
+#      context: ./
+#      dockerfile: docker/db.dockerfile
+#    volumes:
+#      - ~/.docker/dashboard_test_db:/var/lib/mysql
+#    environment:
+#      - "MYSQL_DATABASE=test"
+#      - "MYSQL_USER=tester"
+#      - "MYSQL_PASSWORD=secret"
+#      - "MYSQL_ROOT_PASSWORD=secret"
+#    ports:
+#        - 33061:3306
+
+#  # The Keystore
+#  keystore:
+#    image: redis:3.2
+#    ports:
+#        - 63791:6379

--- a/docker/app.dockerfile
+++ b/docker/app.dockerfile
@@ -1,0 +1,15 @@
+FROM php:7.0-fpm
+
+RUN apt-get update && apt-get install -y libpng-dev libfreetype6-dev libjpeg62-turbo-dev zlib1g-dev libxrender1 libmcrypt-dev  git\
+    && docker-php-ext-install zip\
+    && docker-php-ext-install pdo pdo_mysql\
+    && docker-php-ext-install bcmath mbstring\
+    && docker-php-ext-install mcrypt\
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/\
+    && docker-php-ext-install gd
+
+RUN curl -sS https://getcomposer.org/installer | php \
+    && mv composer.phar /usr/local/bin/ \
+    && ln -s /usr/local/bin/composer.phar /usr/local/bin/composer
+
+RUN chmod 777 -R /tmp && chmod o+t -R /tmp

--- a/docker/app.dockerfile
+++ b/docker/app.dockerfile
@@ -1,12 +1,17 @@
 FROM php:7.0-fpm
 
 RUN apt-get update && apt-get install -y libpng-dev libfreetype6-dev libjpeg62-turbo-dev zlib1g-dev libxrender1 libmcrypt-dev  git\
-    && docker-php-ext-install zip\
-    && docker-php-ext-install pdo pdo_mysql\
-    && docker-php-ext-install bcmath mbstring\
-    && docker-php-ext-install mcrypt\
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/\
-    && docker-php-ext-install gd
+    && docker-php-ext-install zip pdo pdo_mysql bcmath mbstring mcrypt gd
+
+RUN apt-get update \
+  && apt-get install -y libmemcached11 libmemcachedutil2 build-essential libmemcached-dev libz-dev \
+  && pecl install memcached \
+  && echo extension=memcached.so >> /usr/local/etc/php/conf.d/memcached.ini \
+  && apt-get remove -y build-essential libmemcached-dev libz-dev \
+  && apt-get autoremove -y \
+  && apt-get clean \
+  && rm -rf /tmp/pear
 
 RUN curl -sS https://getcomposer.org/installer | php \
     && mv composer.phar /usr/local/bin/ \

--- a/docker/db.dockerfile
+++ b/docker/db.dockerfile
@@ -1,0 +1,3 @@
+FROM percona:5.7
+
+ADD docker/my.cnf /etc/mysql/conf.d/my.cnf

--- a/docker/my.cnf
+++ b/docker/my.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+max_connections = 1000

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,6 +12,9 @@
          syntaxCheck="true"
          verbose="true"
 >
+    <listeners>
+        <listener class="\Mockery\Adapter\Phpunit\TestListener"></listener>
+    </listeners>
     <testsuites>
         <testsuite name="Laravel Test Suite">
             <directory suffix="Test.php">./tests</directory>

--- a/src/Illuminate/Exception/ExceptionDisplayerInterface.php
+++ b/src/Illuminate/Exception/ExceptionDisplayerInterface.php
@@ -1,14 +1,14 @@
 <?php namespace Illuminate\Exception;
 
-use Exception;
+use Throwable;
 
 interface ExceptionDisplayerInterface {
 
 	/**
 	 * Display the given exception to the user.
 	 *
-	 * @param  \Exception  $exception
+	 * @param  \Throwable  $exception
 	 */
-	public function display(Exception $exception);
+	public function display(Throwable $exception);
 
 }

--- a/src/Illuminate/Exception/Handler.php
+++ b/src/Illuminate/Exception/Handler.php
@@ -139,7 +139,7 @@ class Handler {
 	/**
 	 * Handle an exception for the application.
 	 *
-	 * @param  \Exception  $exception
+	 * @param  \Throwable  $exception
 	 * @return \Symfony\Component\HttpFoundation\Response
 	 */
 	public function handleException($exception)
@@ -163,7 +163,7 @@ class Handler {
 	/**
 	 * Handle an uncaught exception.
 	 *
-	 * @param  \Exception  $exception
+	 * @param  \Throwable  $exception
 	 * @return void
 	 */
 	public function handleUncaughtException($exception)
@@ -207,7 +207,7 @@ class Handler {
 	/**
 	 * Handle a console exception.
 	 *
-	 * @param  \Exception  $exception
+	 * @param  \Throwable  $exception
 	 * @return void
 	 */
 	public function handleConsole($exception)
@@ -218,7 +218,7 @@ class Handler {
 	/**
 	 * Handle the given exception.
 	 *
-	 * @param  \Exception  $exception
+	 * @param  \Throwable  $exception
 	 * @param  bool  $fromConsole
 	 * @return void
 	 */
@@ -253,10 +253,6 @@ class Handler {
 			{
 				$response = $handler($exception, $code, $fromConsole);
 			}
-			catch (\Exception $e)
-			{
-				$response = $this->formatException($e);
-			}
 			catch (\Throwable $e)
 			{
 				$response = $this->formatException($e);
@@ -275,17 +271,12 @@ class Handler {
 	/**
 	 * Display the given exception to the user.
 	 *
-	 * @param  \Exception  $exception
+	 * @param  \Throwable  $exception
 	 * @return void
 	 */
 	protected function displayException($exception)
 	{
 		$displayer = $this->debug ? $this->debugDisplayer : $this->plainDisplayer;
-
-		if (! $exception instanceof \Exception) {
-			$exception = new FatalThrowableError($exception);
-		}
-
 		return $displayer->display($exception);
 	}
 
@@ -293,7 +284,7 @@ class Handler {
 	 * Determine if the given handler handles this exception.
 	 *
 	 * @param  \Closure    $handler
-	 * @param  \Exception  $exception
+	 * @param  \Throwable  $exception
 	 * @return bool
 	 */
 	protected function handlesException(Closure $handler, $exception)
@@ -307,7 +298,7 @@ class Handler {
 	 * Determine if the given handler type hints the exception.
 	 *
 	 * @param  \ReflectionFunction  $reflection
-	 * @param  \Exception  $exception
+	 * @param  \Throwable  $exception
 	 * @return bool
 	 */
 	protected function hints(ReflectionFunction $reflection, $exception)
@@ -322,10 +313,10 @@ class Handler {
 	/**
 	 * Format an exception thrown by a handler.
 	 *
-	 * @param  \Exception  $e
+	 * @param  \Throwable  $e
 	 * @return string
 	 */
-	protected function formatException(\Exception $e)
+	protected function formatException(\Throwable $e)
 	{
 		if ($this->debug)
 		{

--- a/src/Illuminate/Exception/PlainDisplayer.php
+++ b/src/Illuminate/Exception/PlainDisplayer.php
@@ -1,6 +1,6 @@
 <?php namespace Illuminate\Exception;
 
-use Exception;
+use Throwable;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 
@@ -9,10 +9,10 @@ class PlainDisplayer implements ExceptionDisplayerInterface {
 	/**
 	 * Display the given exception to the user.
 	 *
-	 * @param  \Exception  $exception
+	 * @param  \Throwable  $exception
 	 * @return \Symfony\Component\HttpFoundation\Response
 	 */
-	public function display(Exception $exception)
+	public function display(Throwable $exception)
 	{
 		$status = $exception instanceof HttpExceptionInterface ? $exception->getStatusCode() : 500;
 

--- a/src/Illuminate/Exception/SymfonyDisplayer.php
+++ b/src/Illuminate/Exception/SymfonyDisplayer.php
@@ -1,6 +1,6 @@
 <?php namespace Illuminate\Exception;
 
-use Exception;
+use Throwable;
 use Symfony\Component\Debug\ExceptionHandler;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
@@ -36,10 +36,10 @@ class SymfonyDisplayer implements ExceptionDisplayerInterface {
 	/**
 	 * Display the given exception to the user.
 	 *
-	 * @param  \Exception  $exception
+	 * @param  \Throwable  $exception
 	 * @return \Symfony\Component\HttpFoundation\Response
 	 */
-	public function display(Exception $exception)
+	public function display(Throwable $exception)
 	{
 		if ($this->returnJson)
 		{

--- a/src/Illuminate/Exception/WhoopsDisplayer.php
+++ b/src/Illuminate/Exception/WhoopsDisplayer.php
@@ -1,6 +1,6 @@
 <?php namespace Illuminate\Exception;
 
-use Exception;
+use Throwable;
 use Whoops\Run;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
@@ -37,10 +37,10 @@ class WhoopsDisplayer implements ExceptionDisplayerInterface {
 	/**
 	 * Display the given exception to the user.
 	 *
-	 * @param  \Exception  $exception
+	 * @param  \Throwable  $exception
 	 * @return \Symfony\Component\HttpFoundation\Response
 	 */
-	public function display(Exception $exception)
+	public function display(Throwable $exception)
 	{
 		$status = $exception instanceof HttpExceptionInterface ? $exception->getStatusCode() : 500;
 

--- a/tests/Auth/AuthDatabaseReminderRepositoryTest.php
+++ b/tests/Auth/AuthDatabaseReminderRepositoryTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class AuthDatabaseReminderRepositoryTest extends PHPUnit_Framework_TestCase {
+class AuthDatabaseReminderRepositoryTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Auth/AuthDatabaseUserProviderTest.php
+++ b/tests/Auth/AuthDatabaseUserProviderTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class AuthDatabaseUserProviderTest extends PHPUnit_Framework_TestCase {
+class AuthDatabaseUserProviderTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class AuthEloquentUserProviderTest extends PHPUnit_Framework_TestCase {
+class AuthEloquentUserProviderTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Symfony\Component\HttpFoundation\Request;
 
-class AuthGuardTest extends PHPUnit_Framework_TestCase {
+class AuthGuardTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Auth\Reminders\PasswordBroker;
 
-class AuthPasswordBrokerTest extends PHPUnit_Framework_TestCase {
+class AuthPasswordBrokerTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Cache/CacheApcStoreTest.php
+++ b/tests/Cache/CacheApcStoreTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class CacheApcStoreTest extends PHPUnit_Framework_TestCase {
+class CacheApcStoreTest extends TestCase {
 
 	public function testGetReturnsNullWhenNotFound()
 	{

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Cache\ArrayStore;
 
-class CacheArrayStoreTest extends PHPUnit_Framework_TestCase {
+class CacheArrayStoreTest extends TestCase {
 
 	public function testItemsCanBeSetAndRetrieved()
 	{

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Cache\DatabaseStore;
 
-class CacheDatabaseStoreTest extends PHPUnit_Framework_TestCase {
+class CacheDatabaseStoreTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Cache\FileStore;
 
-class CacheFileStoreTest extends PHPUnit_Framework_TestCase {
+class CacheFileStoreTest extends TestCase {
 
 	public function testNullIsReturnedIfFileDoesntExist()
 	{

--- a/tests/Cache/CacheMemcachedConnectorTest.php
+++ b/tests/Cache/CacheMemcachedConnectorTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class CacheMemcachedConnectorTest extends PHPUnit_Framework_TestCase {
+class CacheMemcachedConnectorTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Cache/CacheMemcachedStoreTest.php
+++ b/tests/Cache/CacheMemcachedStoreTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class CacheMemcachedStoreTest extends PHPUnit_Framework_TestCase {
+class CacheMemcachedStoreTest extends TestCase {
 
 	public function testGetReturnsNullWhenNotFound()
 	{

--- a/tests/Cache/CacheNullStoreTest.php
+++ b/tests/Cache/CacheNullStoreTest.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Cache\NullStore;
 
-class CacheNullStoreTest extends PHPUnit_Framework_TestCase {
+class CacheNullStoreTest extends TestCase {
 
 	public function testItemsCanNotBeCached()
 	{

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class CacheRedisStoreTest extends PHPUnit_Framework_TestCase {
+class CacheRedisStoreTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class CacheRepositoryTest extends PHPUnit_Framework_TestCase {
+class CacheRepositoryTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Cache\ArrayStore;
 
-class CacheTaggedCacheTest extends PHPUnit_Framework_TestCase {
+class CacheTaggedCacheTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Config/ConfigFileLoaderTest.php
+++ b/tests/Config/ConfigFileLoaderTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class ConfigFileLoaderTest extends PHPUnit_Framework_TestCase {
+class ConfigFileLoaderTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Config/ConfigRepositoryTest.php
+++ b/tests/Config/ConfigRepositoryTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class ConfigRepositoryTest extends PHPUnit_Framework_TestCase {
+class ConfigRepositoryTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class ConsoleApplicationTest extends PHPUnit_Framework_TestCase {
+class ConsoleApplicationTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Container\Container;
 
-class ContainerContainerTest extends PHPUnit_Framework_TestCase {
+class ContainerContainerTest extends TestCase {
 
 	public function testClosureResolution()
 	{
@@ -323,7 +323,7 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 
 	public function testInternalClassWithDefaultParameters()
 	{
-		$this->setExpectedException('Illuminate\Container\BindingResolutionException', 'Unresolvable dependency resolving [Parameter #0 [ <required> $first ]] in class ContainerMixedPrimitiveStub');
+		$this->expectException('Illuminate\Container\BindingResolutionException', 'Unresolvable dependency resolving [Parameter #0 [ <required> $first ]] in class ContainerMixedPrimitiveStub');
 		$container = new Container;
 		$parameters = array();
 		$container->make('ContainerMixedPrimitiveStub', $parameters);

--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -4,7 +4,7 @@ use Mockery as m;
 use Illuminate\Cookie\CookieJar;
 use Symfony\Component\HttpFoundation\Request;
 
-class CookieTest extends PHPUnit_Framework_TestCase {
+class CookieTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -6,7 +6,7 @@ class DatabaseConnectionFactoryPDOStub extends PDO {
 	public function __construct() {}
 }
 
-class DatabaseConnectionFactoryTest extends PHPUnit_Framework_TestCase {
+class DatabaseConnectionFactoryTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class DatabaseConnectionTest extends PHPUnit_Framework_TestCase {
+class DatabaseConnectionTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class DatabaseConnectorTest extends PHPUnit_Framework_TestCase {
+class DatabaseConnectorTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -4,7 +4,7 @@ use Mockery as m;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
-class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
+class DatabaseEloquentBelongsToManyTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -4,7 +4,7 @@ use Mockery as m;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
-class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase {
+class DatabaseEloquentBelongsToTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -4,7 +4,7 @@ use Mockery as m;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 
-class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
+class DatabaseEloquentBuilderTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Database\Eloquent\Collection;
 
-class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
+class DatabaseEloquentCollectionTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -4,7 +4,7 @@ use Mockery as m;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
-class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase {
+class DatabaseEloquentHasManyTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabaseEloquentHasManyThroughTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughTest.php
@@ -4,7 +4,7 @@ use Mockery as m;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 
-class DatabaseEloquentHasManyThroughTest extends PHPUnit_Framework_TestCase {
+class DatabaseEloquentHasManyThroughTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -4,7 +4,7 @@ use Mockery as m;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 
-class DatabaseEloquentHasOneTest extends PHPUnit_Framework_TestCase {
+class DatabaseEloquentHasOneTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
+class DatabaseEloquentModelTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -4,7 +4,7 @@ use Mockery as m;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 
-class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase {
+class DatabaseEloquentMorphTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 
-class DatabaseEloquentMorphToManyTest extends PHPUnit_Framework_TestCase {
+class DatabaseEloquentMorphToManyTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -4,7 +4,7 @@ use Mockery as m;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
-class DatabaseEloquentMorphToTest extends PHPUnit_Framework_TestCase {
+class DatabaseEloquentMorphToTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 
-class DatabaseEloquentPivotTest extends PHPUnit_Framework_TestCase {
+class DatabaseEloquentPivotTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 
-class DatabaseEloquentRelationTest extends PHPUnit_Framework_TestCase {
+class DatabaseEloquentRelationTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Database\Migrations\MigrationCreator;
 
-class DatabaseMigrationCreatorTest extends PHPUnit_Framework_TestCase {
+class DatabaseMigrationCreatorTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabaseMigrationInstallCommandTest.php
+++ b/tests/Database/DatabaseMigrationInstallCommandTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class DatabaseMigrationInstallCommandTest extends PHPUnit_Framework_TestCase {
+class DatabaseMigrationInstallCommandTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Database\Console\Migrations\MigrateMakeCommand;
 
-class DatabaseMigrationMakeCommandTest extends PHPUnit_Framework_TestCase {
+class DatabaseMigrationMakeCommandTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Database\Console\Migrations\MigrateCommand;
 
-class DatabaseMigrationMigrateCommandTest extends PHPUnit_Framework_TestCase {
+class DatabaseMigrationMigrateCommandTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabaseMigrationRepositoryTest.php
+++ b/tests/Database/DatabaseMigrationRepositoryTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Database\Migrations\DatabaseMigrationRepository;
 
-class DatabaseMigrationRepositoryTest extends PHPUnit_Framework_TestCase {
+class DatabaseMigrationRepositoryTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabaseMigrationResetCommandTest.php
+++ b/tests/Database/DatabaseMigrationResetCommandTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Database\Console\Migrations\ResetCommand;
 
-class DatabaseMigrationResetCommandTest extends PHPUnit_Framework_TestCase {
+class DatabaseMigrationResetCommandTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Database\Console\Migrations\RollbackCommand;
 
-class DatabaseMigrationRollbackCommandTest extends PHPUnit_Framework_TestCase {
+class DatabaseMigrationRollbackCommandTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabaseMigratorTest.php
+++ b/tests/Database/DatabaseMigratorTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
+class DatabaseMigratorTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabaseMySqlProcessorTest.php
+++ b/tests/Database/DatabaseMySqlProcessorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class DatabaseMySqlProcessorTest extends PHPUnit_Framework_TestCase {
+class DatabaseMySqlProcessorTest extends TestCase {
 
 	public function testProcessColumnListing()
 	{

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Database\Schema\Blueprint;
 
-class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase {
+class DatabaseMySqlSchemaGrammarTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabasePostgresProcessorTest.php
+++ b/tests/Database/DatabasePostgresProcessorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class DatabasePostgresProcessorTest extends PHPUnit_Framework_TestCase {
+class DatabasePostgresProcessorTest extends TestCase {
 
 	public function testProcessColumnListing()
 	{

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Database\Schema\Blueprint;
 
-class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase {
+class DatabasePostgresSchemaGrammarTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabaseProcessorTest.php
+++ b/tests/Database/DatabaseProcessorTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class DatabaseProcessorTest extends PHPUnit_Framework_TestCase {
+class DatabaseProcessorTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -4,7 +4,7 @@ use Mockery as m;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\Expression as Raw;
 
-class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
+class DatabaseQueryBuilderTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabaseSQLiteProcessorTest.php
+++ b/tests/Database/DatabaseSQLiteProcessorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class DatabaseSQLiteProcessorTest extends PHPUnit_Framework_TestCase {
+class DatabaseSQLiteProcessorTest extends TestCase {
 
 	public function testProcessColumnListing()
 	{

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Database\Schema\Blueprint;
 
-class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase {
+class DatabaseSQLiteSchemaGrammarTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Database\Schema\Blueprint;
 
-class DatabaseSchemaBlueprintTest extends PHPUnit_Framework_TestCase {
+class DatabaseSchemaBlueprintTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabaseSchemaBuilderTest.php
+++ b/tests/Database/DatabaseSchemaBuilderTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Database\Schema\Builder;
 
-class DatabaseSchemaBuilderTest extends PHPUnit_Framework_TestCase {
+class DatabaseSchemaBuilderTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabaseSeederTest.php
+++ b/tests/Database/DatabaseSeederTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Database\Seeder;
 
-class DatabaseSeederTest extends PHPUnit_Framework_TestCase {
+class DatabaseSeederTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabaseSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseSoftDeletingScopeTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class DatabaseSoftDeletingScopeTest extends PHPUnit_Framework_TestCase {
+class DatabaseSoftDeletingScopeTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class DatabaseSoftDeletingTraitTest extends PHPUnit_Framework_TestCase {
+class DatabaseSoftDeletingTraitTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Database\Schema\Blueprint;
 
-class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase {
+class DatabaseSqlServerSchemaGrammarTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Encryption\Encrypter;
 
-class EncrypterTest extends PHPUnit_Framework_TestCase {
+class EncrypterTest extends TestCase {
 
 	public function testEncryption()
 	{

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Events\Dispatcher;
 
-class EventsDispatcherTest extends PHPUnit_Framework_TestCase {
+class EventsDispatcherTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Exception/HandlerTest.php
+++ b/tests/Exception/HandlerTest.php
@@ -3,7 +3,7 @@
 use Illuminate\Exception\Handler;
 use Mockery as m;
 
-class HandlerTest extends PHPUnit_Framework_TestCase
+class HandlerTest extends TestCase
 {
 	protected function setUp()
 	{

--- a/tests/Exception/PlainDisplayerTest.php
+++ b/tests/Exception/PlainDisplayerTest.php
@@ -3,7 +3,7 @@
 use Illuminate\Exception\PlainDisplayer;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
-class PlainDisplayerTest extends PHPUnit_Framework_TestCase {
+class PlainDisplayerTest extends TestCase {
 
 	public function testStatusAndHeadersAreSetInResponse()
 	{

--- a/tests/Exception/WhoopsDisplayerTest.php
+++ b/tests/Exception/WhoopsDisplayerTest.php
@@ -14,9 +14,8 @@ class WhoopsDisplayerTest extends PHPUnit_Framework_TestCase {
 
 	public function testStatusAndHeadersAreSetInResponse()
 	{
-		$mockWhoops = m::mock('Whoops\Run[handleException]');
-		$mockWhoops->shouldReceive('handleException')->andReturn('response content');
-		$displayer = new WhoopsDisplayer($mockWhoops, false);
+	    $run = new \Whoops\Run();
+		$displayer = new WhoopsDisplayer($run, false);
 		$headers = array('X-My-Test-Header' => 'HeaderValue');
 		$exception = new HttpException(401, 'Unauthorized', null, $headers);
 		$response = $displayer->display($exception);

--- a/tests/Exception/WhoopsDisplayerTest.php
+++ b/tests/Exception/WhoopsDisplayerTest.php
@@ -4,7 +4,7 @@ use Illuminate\Exception\WhoopsDisplayer;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Mockery as m;
 
-class WhoopsDisplayerTest extends PHPUnit_Framework_TestCase {
+class WhoopsDisplayerTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Filesystem\Filesystem;
 
-class FilesystemTest extends PHPUnit_Framework_TestCase {
+class FilesystemTest extends TestCase {
 
 	public function testGetRetrievesFiles()
 	{

--- a/tests/Foundation/FoundationAliasLoaderTest.php
+++ b/tests/Foundation/FoundationAliasLoaderTest.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Foundation\AliasLoader;
 
-class FoundationAliasLoaderTest extends PHPUnit_Framework_TestCase {
+class FoundationAliasLoaderTest extends TestCase {
 
 	public function testLoaderCanBeCreatedAndRegisteredOnce()
 	{

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Foundation\Application;
 
-class FoundationApplicationTest extends PHPUnit_Framework_TestCase {
+class FoundationApplicationTest extends TestCase {
 
 	public function tearDown()
 	{
@@ -126,7 +126,7 @@ class FoundationApplicationTest extends PHPUnit_Framework_TestCase {
 
 	public function testHandleRespectsCatchArgument()
 	{
-		$this->setExpectedException('Exception');
+		$this->expectException('Exception');
 		$app = new Application;
 		$app['router'] = $router = m::mock('StdClass');
 		$router->shouldReceive('dispatch')->andThrow('Exception');

--- a/tests/Foundation/FoundationArtisanTest.php
+++ b/tests/Foundation/FoundationArtisanTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class FoundationArtisanTest extends PHPUnit_Framework_TestCase {
+class FoundationArtisanTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Foundation/FoundationAssetPublishCommandTest.php
+++ b/tests/Foundation/FoundationAssetPublishCommandTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class FoundationAssetPublishCommandTest extends PHPUnit_Framework_TestCase {
+class FoundationAssetPublishCommandTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Foundation/FoundationAssetPublisherTest.php
+++ b/tests/Foundation/FoundationAssetPublisherTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class FoundationAssetPublisherTest extends PHPUnit_Framework_TestCase {
+class FoundationAssetPublisherTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Foundation/FoundationComposerTest.php
+++ b/tests/Foundation/FoundationComposerTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class FoundationComposerTest extends PHPUnit_Framework_TestCase {
+class FoundationComposerTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Foundation/FoundationConfigPublishCommandTest.php
+++ b/tests/Foundation/FoundationConfigPublishCommandTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class FoundationConfigPublishCommandTest extends PHPUnit_Framework_TestCase {
+class FoundationConfigPublishCommandTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Foundation/FoundationConfigPublisherTest.php
+++ b/tests/Foundation/FoundationConfigPublisherTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class FoundationConfigPublisherTest extends PHPUnit_Framework_TestCase {
+class FoundationConfigPublisherTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Foundation/FoundationEnvironmentDetectorTest.php
+++ b/tests/Foundation/FoundationEnvironmentDetectorTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class FoundationEnvironmentDetectorTest extends PHPUnit_Framework_TestCase {
+class FoundationEnvironmentDetectorTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Foundation/FoundationViewPublishCommandTest.php
+++ b/tests/Foundation/FoundationViewPublishCommandTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class FoundationViewPublishCommandTest extends PHPUnit_Framework_TestCase {
+class FoundationViewPublishCommandTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Foundation/FoundationViewPublisherTest.php
+++ b/tests/Foundation/FoundationViewPublisherTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class FoundationViewPublisherTest extends PHPUnit_Framework_TestCase {
+class FoundationViewPublisherTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Foundation/ProviderRepositoryTest.php
+++ b/tests/Foundation/ProviderRepositoryTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class ProviderRepositoryTest extends PHPUnit_Framework_TestCase {
+class ProviderRepositoryTest extends TestCase {
 
 	public function tearDown()
 	{
@@ -102,7 +102,7 @@ class ProviderRepositoryTest extends PHPUnit_Framework_TestCase {
 	public function testWriteManifestStoresToProperLocation()
 	{
 		$repo = new Illuminate\Foundation\ProviderRepository($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
-		$files->shouldReceive('put')->once()->with(__DIR__.'/services.json', json_encode(array('foo')));
+		$files->shouldReceive('put')->once()->with(__DIR__.'/services.json', json_encode(array('foo'), JSON_PRETTY_PRINT));
 
 		$result = $repo->writeManifest(array('foo'));
 

--- a/tests/Hashing/BcryptHasherTest.php
+++ b/tests/Hashing/BcryptHasherTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class BcryptHasherTest extends PHPUnit_Framework_TestCase {
+class BcryptHasherTest extends TestCase {
 
 	public function testBasicHashing()
 	{

--- a/tests/Html/FormBuilderTest.php
+++ b/tests/Html/FormBuilderTest.php
@@ -7,7 +7,7 @@ use Illuminate\Html\HtmlBuilder;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Routing\RouteCollection;
 
-class FormBuilderTest extends PHPUnit_Framework_TestCase {
+class FormBuilderTest extends TestCase {
 
 	/**
 	 * Setup the test environment.

--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class HttpJsonResponseTest extends PHPUnit_Framework_TestCase {
+class HttpJsonResponseTest extends TestCase {
 
 	public function testSetAndRetrieveData()
 	{

--- a/tests/Http/HttpRedirectResponseTest.php
+++ b/tests/Http/HttpRedirectResponseTest.php
@@ -4,7 +4,7 @@ use Mockery as m;
 use Illuminate\Http\Request;
 use Illuminate\Http\RedirectResponse;
 
-class HttpRedirectResponseTest extends PHPUnit_Framework_TestCase {
+class HttpRedirectResponseTest extends TestCase {
 
 	public function tearDown()
 	{
@@ -128,7 +128,7 @@ class HttpRedirectResponseTest extends PHPUnit_Framework_TestCase {
 
 	public function testMagicCallException()
 	{
-		$this->setExpectedException('BadMethodCallException');
+		$this->expectException('BadMethodCallException');
 		$response = new RedirectResponse('foo.bar');
 		$response->doesNotExist('bar');
 	}

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -4,7 +4,7 @@ use Mockery as m;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
-class HttpRequestTest extends PHPUnit_Framework_TestCase {
+class HttpRequestTest extends TestCase {
 
 	public function tearDown()
 	{
@@ -388,7 +388,7 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 
 	public function testSessionMethod()
 	{
-		$this->setExpectedException('RuntimeException');
+		$this->expectException('RuntimeException');
 		$request = Request::create('/', 'GET');
 		$request->session();
 	}

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Support\Contracts\JsonableInterface;
 
-class HttpResponseTest extends PHPUnit_Framework_TestCase {
+class HttpResponseTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Log/LogWriterTest.php
+++ b/tests/Log/LogWriterTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Log\Writer;
 
-class LogWriterTest extends PHPUnit_Framework_TestCase {
+class LogWriterTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class MailMailerTest extends PHPUnit_Framework_TestCase {
+class MailMailerTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class MailMessageTest extends PHPUnit_Framework_TestCase {
+class MailMessageTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Pagination/PaginationBootstrapPresenterTest.php
+++ b/tests/Pagination/PaginationBootstrapPresenterTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Pagination\BootstrapPresenter;
 
-class PaginationBootstrapPresenterTest extends PHPUnit_Framework_TestCase {
+class PaginationBootstrapPresenterTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Pagination/PaginationCustomPresenterTest.php
+++ b/tests/Pagination/PaginationCustomPresenterTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class PaginationCustomPresenterTest extends PHPUnit_Framework_TestCase {
+class PaginationCustomPresenterTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Pagination/PaginationFactoryTest.php
+++ b/tests/Pagination/PaginationFactoryTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Pagination\Factory;
 
-class PaginationFactoryTest extends PHPUnit_Framework_TestCase {
+class PaginationFactoryTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Pagination/PaginationPaginatorTest.php
+++ b/tests/Pagination/PaginationPaginatorTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Pagination\Paginator;
 
-class PaginationPaginatorTest extends PHPUnit_Framework_TestCase {
+class PaginationPaginatorTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Queue/QueueBeanstalkdJobTest.php
+++ b/tests/Queue/QueueBeanstalkdJobTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class QueueBeanstalkdJobTest extends PHPUnit_Framework_TestCase {
+class QueueBeanstalkdJobTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Queue/QueueBeanstalkdQueueTest.php
+++ b/tests/Queue/QueueBeanstalkdQueueTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class QueueBeanstalkdQueueTest extends PHPUnit_Framework_TestCase {
+class QueueBeanstalkdQueueTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Queue/QueueIronJobTest.php
+++ b/tests/Queue/QueueIronJobTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class QueueIronJobTest extends PHPUnit_Framework_TestCase {
+class QueueIronJobTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Queue/QueueIronQueueTest.php
+++ b/tests/Queue/QueueIronQueueTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class QueueIronQueueTest extends PHPUnit_Framework_TestCase {
+class QueueIronQueueTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Queue/QueueListenerTest.php
+++ b/tests/Queue/QueueListenerTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class QueueListenerTest extends PHPUnit_Framework_TestCase {
+class QueueListenerTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Queue/QueueManagerTest.php
+++ b/tests/Queue/QueueManagerTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Queue\QueueManager;
 
-class QueueManagerTest extends PHPUnit_Framework_TestCase {
+class QueueManagerTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Queue/QueueRedisJobTest.php
+++ b/tests/Queue/QueueRedisJobTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class QueueRedisJobTest extends PHPUnit_Framework_TestCase {
+class QueueRedisJobTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class QueueRedisQueueTest extends PHPUnit_Framework_TestCase {
+class QueueRedisQueueTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Queue/QueueSqsJobTest.php
+++ b/tests/Queue/QueueSqsJobTest.php
@@ -6,7 +6,7 @@ use Guzzle\Common\Collection;
 use Aws\Common\Signature\SignatureV4;
 use Aws\Common\Credentials\Credentials;
 
-class QueueSqsJobTest extends PHPUnit_Framework_TestCase {
+class QueueSqsJobTest extends TestCase {
 
 	public function setUp() {
 

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -5,7 +5,7 @@ use Mockery as m;
 use Aws\Sqs\SqsClient;
 use Guzzle\Service\Resource\Model;
 
-class QueueSqsQueueTest extends PHPUnit_Framework_TestCase {
+class QueueSqsQueueTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Queue/QueueSyncJobTest.php
+++ b/tests/Queue/QueueSyncJobTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class QueueSyncJobTest extends PHPUnit_Framework_TestCase {
+class QueueSyncJobTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class QueueSyncQueueTest extends PHPUnit_Framework_TestCase {
+class QueueSyncQueueTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Queue\Worker;
 
-class QueueWorkerTest extends PHPUnit_Framework_TestCase {
+class QueueWorkerTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Remote/RemoteSecLibTest.php
+++ b/tests/Remote/RemoteSecLibTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class RemoteSecLibGatewayTest extends PHPUnit_Framework_TestCase {
+class RemoteSecLibGatewayTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Routing/RoutingControllerDispatcherTest.php
+++ b/tests/Routing/RoutingControllerDispatcherTest.php
@@ -7,7 +7,7 @@ use Illuminate\Routing\Controller;
 use Illuminate\Container\Container;
 use Illuminate\Routing\ControllerDispatcher;
 
-class RoutingControllerDispatcherTest extends PHPUnit_Framework_TestCase {
+class RoutingControllerDispatcherTest extends TestCase {
 
 	public function setUp()
 	{

--- a/tests/Routing/RoutingControllerGeneratorTest.php
+++ b/tests/Routing/RoutingControllerGeneratorTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Routing\Generators\ControllerGenerator;
 
-class RoutingControllerGeneratorTest extends PHPUnit_Framework_TestCase {
+class RoutingControllerGeneratorTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Routing/RoutingControllerInspectorTest.php
+++ b/tests/Routing/RoutingControllerInspectorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class RoutingControllerInspectorTest extends PHPUnit_Framework_TestCase {
+class RoutingControllerInspectorTest extends TestCase {
 
 	public function testMethodsAreCorrectlyDetermined()
 	{

--- a/tests/Routing/RoutingMakeControllerCommandTest.php
+++ b/tests/Routing/RoutingMakeControllerCommandTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class RoutingMakeControllerCommandTest extends PHPUnit_Framework_TestCase {
+class RoutingMakeControllerCommandTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Routing\Redirector;
 
-class RoutingRedirectorTest extends PHPUnit_Framework_TestCase {
+class RoutingRedirectorTest extends TestCase {
 
 	protected $headers;
 	protected $request;

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -4,7 +4,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\Router;
 
-class RoutingRouteTest extends PHPUnit_Framework_TestCase {
+class RoutingRouteTest extends TestCase {
 
 	public function testBasicDispatchingOfRoutes()
 	{

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Routing\UrlGenerator;
 
-class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
+class RoutingUrlGeneratorTest extends TestCase {
 
 	public function testBasicGeneration()
 	{

--- a/tests/Session/SessionMiddlewareTest.php
+++ b/tests/Session/SessionMiddlewareTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class SessionMiddlewareTest extends PHPUnit_Framework_TestCase {
+class SessionMiddlewareTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class SessionStoreTest extends PHPUnit_Framework_TestCase {
+class SessionStoreTest extends TestCase {
 
 	public function tearDown()
 	{
@@ -32,7 +32,7 @@ class SessionStoreTest extends PHPUnit_Framework_TestCase {
 
 	public function testSessionGetBagException()
 	{
-		$this->setExpectedException('InvalidArgumentException');
+		$this->expectException('InvalidArgumentException');
 		$session = $this->getSession();
 		$session->getBag('doesNotExist');
 	}

--- a/tests/Support/SupportCapsuleManagerTraitTest.php
+++ b/tests/Support/SupportCapsuleManagerTraitTest.php
@@ -4,7 +4,7 @@ use Mockery as m;
 use Illuminate\Container\Container;
 use Illuminate\Support\Traits\CapsuleManagerTrait;
 
-class SupportCapsuleManagerTraitTest extends \PHPUnit_Framework_TestCase {
+class SupportCapsuleManagerTraitTest extends TestCase {
 
 	use CapsuleManagerTrait;
 

--- a/tests/Support/SupportClassLoaderTest.php
+++ b/tests/Support/SupportClassLoaderTest.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Support\ClassLoader;
 
-class SupportClassLoaderTest extends PHPUnit_Framework_TestCase {
+class SupportClassLoaderTest extends TestCase {
 
 	public function testNormalizingClass()
 	{

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Support\Collection;
 
-class SupportCollectionTest extends PHPUnit_Framework_TestCase {
+class SupportCollectionTest extends TestCase {
 
 	public function testFirstReturnsFirstItemInCollection()
 	{

--- a/tests/Support/SupportFacadeResponseTest.php
+++ b/tests/Support/SupportFacadeResponseTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Support\Facades\Response;
 
-class SupportFacadeResponseTest extends PHPUnit_Framework_TestCase {
+class SupportFacadeResponseTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class SupportFacadeTest extends PHPUnit_Framework_TestCase {
+class SupportFacadeTest extends TestCase {
 
 	public function setUp()
 	{

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Support\Fluent;
 
-class SupportFluentTest extends PHPUnit_Framework_TestCase {
+class SupportFluentTest extends TestCase {
 
 	public function testAttributesAreSetByConstructor()
 	{

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class SupportHelpersTest extends PHPUnit_Framework_TestCase {
+class SupportHelpersTest extends TestCase {
 
 	public function testArrayBuild()
 	{

--- a/tests/Support/SupportMacroTraitTest.php
+++ b/tests/Support/SupportMacroTraitTest.php
@@ -1,7 +1,7 @@
 <?php
 
 
-class SupportMacroTraitTest extends \PHPUnit_Framework_TestCase {
+class SupportMacroTraitTest extends TestCase {
 
 	private $macroTrait;
 

--- a/tests/Support/SupportMessageBagTest.php
+++ b/tests/Support/SupportMessageBagTest.php
@@ -3,7 +3,7 @@
 use Illuminate\Support\MessageBag;
 use Mockery as m;
 
-class SupportMessageBagTest extends PHPUnit_Framework_TestCase {
+class SupportMessageBagTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Support/SupportNamespacedItemResolverTest.php
+++ b/tests/Support/SupportNamespacedItemResolverTest.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Support\NamespacedItemResolver;
 
-class SupportNamespacedItemResolverTest extends PHPUnit_Framework_TestCase {
+class SupportNamespacedItemResolverTest extends TestCase {
 
 	public function testResolution()
 	{

--- a/tests/Support/SupportPluralizerTest.php
+++ b/tests/Support/SupportPluralizerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class SupportPluralizerTest extends PHPUnit_Framework_TestCase {
+class SupportPluralizerTest extends TestCase {
 
 	public function testBasicUsage()
 	{

--- a/tests/Support/SupportSerializableClosureTest.php
+++ b/tests/Support/SupportSerializableClosureTest.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Support\SerializableClosure as S;
 
-class SupportSerializableClosureTest extends PHPUnit_Framework_TestCase {
+class SupportSerializableClosureTest extends TestCase {
 
 	public function testClosureCanBeSerializedAndRebuilt()
 	{

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class SupportServiceProviderTest extends PHPUnit_Framework_TestCase {
+class SupportServiceProviderTest extends TestCase {
 
 	public static function setUpBeforeClass()
 	{

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Support\Str;
 
-class SupportStrTest extends PHPUnit_Framework_TestCase {
+class SupportStrTest extends TestCase {
 
 	/**
 	* Test the Str::words method.

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,48 @@
+<?php
+
+class TestCase extends \PHPUnit\Framework\TestCase
+{
+    use \Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
+    protected $mockObjects;
+
+    protected $mockObjectGenerator;
+
+    /**
+     * @param $originalClassName
+     * @param array $methods
+     * @param array $arguments
+     * @param string $mockClassName
+     * @param bool $callOriginalConstructor
+     * @param bool $callOriginalClone
+     * @param bool $callAutoload
+     * @param bool $cloneArguments
+     * @param bool $callOriginalMethods
+     * @param null $proxyTarget
+     * @return mixed
+     * @throws ReflectionException
+     */
+    public function getMock($originalClassName, $methods = array(), array $arguments = array(), $mockClassName = '', $callOriginalConstructor = true, $callOriginalClone = true, $callAutoload = true, $cloneArguments = false, $callOriginalMethods = false, $proxyTarget = null)
+    {
+        $ref = new ReflectionClass($originalClassName);
+
+        if ($ref->isTrait()) {
+            return $this->getMockForTrait($originalClassName, $arguments, $mockClassName, $callOriginalConstructor, $callOriginalClone, $callAutoload, $methods, $cloneArguments);
+        }
+
+        if ($ref->isAbstract()) {
+            return $this->getMockForAbstractClass($originalClassName, $arguments, $mockClassName, $callOriginalConstructor, $callOriginalClone, $callAutoload, $methods, $cloneArguments);
+        }
+
+        $mock = $this->getMockBuilder($originalClassName)
+            ->setMethods($methods)
+            ->setConstructorArgs($arguments)
+            ->setMockClassName($mockClassName);
+
+        $callOriginalConstructor ? $mock->enableOriginalConstructor() : $mock->disableOriginalConstructor();
+        $callOriginalClone ? $mock->enableOriginalClone() : $mock->disableOriginalClone();
+        $callAutoload ? $mock->enableAutoload() : $mock->disableAutoload();
+        $cloneArguments ? $mock->enableOriginalClone() : $mock->disableOriginalClone();
+        return $mock->getMock();
+    }
+}

--- a/tests/Translation/TranslationFileLoaderTest.php
+++ b/tests/Translation/TranslationFileLoaderTest.php
@@ -4,7 +4,7 @@ use Mockery as m;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Translation\FileLoader;
 
-class TranslationFileLoaderTest extends PHPUnit_Framework_TestCase {
+class TranslationFileLoaderTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Translation\Translator;
 
-class TranslationTranslatorTest extends PHPUnit_Framework_TestCase {
+class TranslationTranslatorTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Validation/ValidationDatabasePresenceVerifierTest.php
+++ b/tests/Validation/ValidationDatabasePresenceVerifierTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class ValidationDatabasePresenceVerifierTest extends PHPUnit_Framework_TestCase {
+class ValidationDatabasePresenceVerifierTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Validation/ValidationFactoryTest.php
+++ b/tests/Validation/ValidationFactoryTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\Validation\Factory;
 
-class ValidationFactoryTest extends PHPUnit_Framework_TestCase {
+class ValidationFactoryTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4,7 +4,7 @@ use Mockery as m;
 use Illuminate\Validation\Validator;
 use Symfony\Component\HttpFoundation\File\File;
 
-class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
+class ValidationValidatorTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\View\Compilers\BladeCompiler;
 
-class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase {
+class ViewBladeCompilerTest extends TestCase {
 
 	public function tearDown()
 	{
@@ -473,7 +473,7 @@ empty
 
 
 	/**
-	 * @dataProvider testGetTagsProvider()
+	 * @dataProvider dataGetTagsProvider()
 	 */
 	public function testSetAndRetrieveContentTags($openingTag, $closingTag)
 	{
@@ -484,7 +484,7 @@ empty
 
 
 	/**
-	 * @dataProvider testGetTagsProvider()
+	 * @dataProvider dataGetTagsProvider()
 	 */
 	public function testSetAndRetrieveEscapedContentTags($openingTag, $closingTag)
 	{
@@ -494,7 +494,7 @@ empty
 	}
 
 
-	public function testGetTagsProvider()
+	public function dataGetTagsProvider()
 	{
 		return [
 			['{{', '}}'],

--- a/tests/View/ViewCompilerEngineTest.php
+++ b/tests/View/ViewCompilerEngineTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\View\Engines\CompilerEngine;
 
-class ViewCompilerEngineTest extends PHPUnit_Framework_TestCase {
+class ViewCompilerEngineTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/View/ViewEngineResolverTest.php
+++ b/tests/View/ViewEngineResolverTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class ViewEngineResolverTest extends PHPUnit_Framework_TestCase {
+class ViewEngineResolverTest extends TestCase {
 
 	public function testResolversMayBeResolved()
 	{
@@ -14,7 +14,7 @@ class ViewEngineResolverTest extends PHPUnit_Framework_TestCase {
 
 	public function testResolverThrowsExceptionOnUnknownEngine()
 	{
-		$this->setExpectedException('InvalidArgumentException');
+		$this->expectException('InvalidArgumentException');
 		$resolver = new Illuminate\View\Engines\EngineResolver;
 		$resolver->resolve('foo');
 	}

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\View\Factory;
 
-class ViewFactoryTest extends PHPUnit_Framework_TestCase {
+class ViewFactoryTest extends TestCase {
 
 	public function tearDown()
 	{
@@ -349,7 +349,7 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase {
 
 	public function testExceptionIsThrownForUnknownExtension()
 	{
-		$this->setExpectedException('InvalidArgumentException');
+		$this->expectException('InvalidArgumentException');
 		$factory = $this->getFactory();
 		$factory->getFinder()->shouldReceive('find')->once()->with('view')->andReturn('view.foo');
 		$factory->make('view');
@@ -367,7 +367,7 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase {
 		$factory->getFinder()->shouldReceive('find')->once()->with('view')->andReturn(__DIR__.'/fixtures/section-exception.php');
 		$factory->getDispatcher()->shouldReceive('fire')->times(4);
 
-		$this->setExpectedException('Exception', 'section exception message');
+		$this->expectException('Exception', 'section exception message');
 		$factory->make('view')->render();
 	}
 

--- a/tests/View/ViewFileViewFinderTest.php
+++ b/tests/View/ViewFileViewFinderTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class ViewFinderTest extends PHPUnit_Framework_TestCase {
+class ViewFinderTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/View/ViewPhpEngineTest.php
+++ b/tests/View/ViewPhpEngineTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use Illuminate\View\Engines\PhpEngine;
 
-class ViewPhpEngineTest extends PHPUnit_Framework_TestCase {
+class ViewPhpEngineTest extends TestCase {
 
 	public function tearDown()
 	{

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -4,7 +4,7 @@ use Mockery as m;
 use Illuminate\View\View;
 use Illuminate\Support\Contracts\ArrayableInterface;
 
-class ViewTest extends PHPUnit_Framework_TestCase {
+class ViewTest extends TestCase {
 
 	public function tearDown()
 	{
@@ -147,7 +147,7 @@ class ViewTest extends PHPUnit_Framework_TestCase {
 
 	public function testViewBadMethod()
 	{
-		$this->setExpectedException('BadMethodCallException');
+		$this->expectException('BadMethodCallException');
 		$view = $this->getView();
 		$view->badMethodCall();
 	}


### PR DESCRIPTION
- Adds a docker dev environment for a quick dev environment.
- Updates minimum version to `>=PHP 7.0`
- Adds support for `Throwable` errors in the error handler
- Whoops is updated to `^2.1` for PHP 7.x compatibility
- Updated PHPUnit to `~6.0` and Mockery to `~1.1`
- Removed the Password Compat dependency; it's only needed for 5.3-5.4 support